### PR TITLE
batching up the console logs sent to cerberus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ type Configuration struct {
 	AnalysisResultWithInvalidControlSearchDays int           `envconfig:"ANALYSIS_RESULT_WITH_INVALID_CONTROL_SEARCH_DAYS" default:"14"`
 	ControlResultSearchDays                    int           `envconfig:"CONTROL_RESULT_SEARCH_DAYS" default:"14"`
 	SampleSeenMessageFlushSeconds              int           `envconfig:"SAMPLE_SEEN_MESSAGE_FLUSH_SECONDS" default:"30"`
+	ConsoleLogFlushSeconds                     int           `envconfig:"CONSOLE_LOG_FLUSH_SECONDS" default:"30"`
 	ClientCredentialAuthHeaderValue            string
 }
 

--- a/service_consolelog.go
+++ b/service_consolelog.go
@@ -1,43 +1,87 @@
 package skeleton
 
 import (
+	"context"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
+	"time"
 )
 
 type ConsoleLogService interface {
 	Debug(instrumentID uuid.UUID, messageType string, message string)
 	Info(instrumentID uuid.UUID, messageType string, message string)
 	Error(instrumentID uuid.UUID, messageType string, message string)
+	StartConsoleLogSending(ctx context.Context)
 }
 
 type consoleLogService struct {
-	cerberusClient CerberusClient
+	cerberusClient         CerberusClient
+	consoleLogDTOChan      chan ConsoleLogDTO
+	consoleLogFlushSeconds int
 }
 
-func NewConsoleLogService(cerberusClient CerberusClient) ConsoleLogService {
+func NewConsoleLogService(cerberusClient CerberusClient, consoleLogFlushSeconds int) ConsoleLogService {
 	return &consoleLogService{
-		cerberusClient: cerberusClient,
+		cerberusClient:         cerberusClient,
+		consoleLogDTOChan:      make(chan ConsoleLogDTO, 1024),
+		consoleLogFlushSeconds: consoleLogFlushSeconds,
 	}
 }
 
 func (s *consoleLogService) Debug(instrumentID uuid.UUID, messageType string, message string) {
-	err := s.cerberusClient.SendConsoleLog(instrumentID, Debug, messageType, message)
-	if err != nil {
-		log.Error().Err(err).Str("InstrumentId", instrumentID.String()).Msg("Error sending console log")
+	s.consoleLogDTOChan <- ConsoleLogDTO{
+		InstrumentID: instrumentID,
+		CreatedAt:    time.Now().UTC(),
+		Level:        Debug,
+		Message:      message,
+		MessageType:  messageType,
 	}
 }
 
 func (s *consoleLogService) Info(instrumentID uuid.UUID, messageType string, message string) {
-	err := s.cerberusClient.SendConsoleLog(instrumentID, Info, messageType, message)
-	if err != nil {
-		log.Error().Err(err).Str("InstrumentId", instrumentID.String()).Msg("Error sending console log")
+	s.consoleLogDTOChan <- ConsoleLogDTO{
+		InstrumentID: instrumentID,
+		CreatedAt:    time.Now().UTC(),
+		Level:        Info,
+		Message:      message,
+		MessageType:  messageType,
 	}
 }
 
 func (s *consoleLogService) Error(instrumentID uuid.UUID, messageType string, message string) {
-	err := s.cerberusClient.SendConsoleLog(instrumentID, Error, messageType, message)
-	if err != nil {
-		log.Error().Err(err).Str("InstrumentId", instrumentID.String()).Msg("Error sending console log")
+	s.consoleLogDTOChan <- ConsoleLogDTO{
+		InstrumentID: instrumentID,
+		CreatedAt:    time.Now().UTC(),
+		Level:        Error,
+		Message:      message,
+		MessageType:  messageType,
+	}
+}
+
+func (s *consoleLogService) StartConsoleLogSending(ctx context.Context) {
+	batchSize := 100
+	batch := make([]ConsoleLogDTO, 0, batchSize)
+	timeout := time.Duration(s.consoleLogFlushSeconds) * time.Second
+	ticker := time.NewTicker(timeout)
+	for {
+		select {
+		case <-ctx.Done():
+			ticker.Stop()
+			return
+		case consoleLogDTO := <-s.consoleLogDTOChan:
+			batch = append(batch, consoleLogDTO)
+			if len(batch) < batchSize {
+				continue
+			}
+			ticker.Stop()
+			s.cerberusClient.SendConsoleLog(batch)
+			batch = make([]ConsoleLogDTO, 0, batchSize)
+			ticker.Reset(timeout)
+		case <-ticker.C:
+			if len(batch) == 0 {
+				continue
+			}
+			s.cerberusClient.SendConsoleLog(batch)
+			batch = make([]ConsoleLogDTO, 0, batchSize)
+		}
 	}
 }

--- a/skeleton.go
+++ b/skeleton.go
@@ -720,6 +720,7 @@ func (s *skeleton) Start() error {
 	for i := 0; i < s.config.AnalysisRequestWorkerPoolSize; i++ {
 		go s.processAnalysisRequests(s.ctx)
 	}
+	go s.consoleLogService.StartConsoleLogSending(s.ctx)
 	go s.messageService.StartDEAArchiving(s.ctx, s.config.MessageMaxRetries)
 	go s.messageService.StartSampleSeenRegisteringToCerberus(s.ctx)
 	go s.messageService.StartSampleCodeRegisteringToDEA(s.ctx)

--- a/skeleton_test.go
+++ b/skeleton_test.go
@@ -77,7 +77,7 @@ func TestSubmitAnalysisResultWithoutRequests(t *testing.T) {
 	sortingRuleRepository := NewSortingRuleRepository(dbConn, schemaName)
 	sortingRuleService := NewSortingRuleService(analysisRepository, conditionService, sortingRuleRepository)
 	instrumentService := NewInstrumentService(sortingRuleService, instrumentRepository, NewSkeletonManager(ctx), NewInstrumentCache(), cerberusClientMock)
-	consoleLogService := NewConsoleLogService(cerberusClientMock)
+	consoleLogService := NewConsoleLogService(cerberusClientMock, 30)
 	messageInRepository := NewMessageInRepository(dbConn, schemaName, 0, 0)
 	messageOutRepository := NewMessageOutRepository(dbConn, schemaName, 0, 0)
 	messageOutOrderRepository := NewMessageOutOrderRepository(dbConn, schemaName, 0)
@@ -168,7 +168,7 @@ func TestSubmitAnalysisResultWithRequests(t *testing.T) {
 	sortingRuleRepository := NewSortingRuleRepository(dbConn, schemaName)
 	sortingRuleService := NewSortingRuleService(analysisRepository, conditionService, sortingRuleRepository)
 	instrumentService := NewInstrumentService(sortingRuleService, instrumentRepository, NewSkeletonManager(ctx), NewInstrumentCache(), cerberusClientMock)
-	consoleLogService := NewConsoleLogService(cerberusClientMock)
+	consoleLogService := NewConsoleLogService(cerberusClientMock, 30)
 	messageInRepository := NewMessageInRepository(dbConn, schemaName, 0, 0)
 	messageOutRepository := NewMessageOutRepository(dbConn, schemaName, 0, 0)
 	messageOutOrderRepository := NewMessageOutOrderRepository(dbConn, schemaName, 0)
@@ -366,7 +366,7 @@ func TestAnalysisResultsReprocessing(t *testing.T) {
 	analysisRepository := NewAnalysisRepository(dbConn, schemaName)
 	sortingRuleService := NewSortingRuleService(analysisRepository, conditionService, sortingRuleRepository)
 	instrumentService := NewInstrumentService(sortingRuleService, instrumentRepository, NewSkeletonManager(ctx), NewInstrumentCache(), cerberusClientMock)
-	consoleLogService := NewConsoleLogService(cerberusClientMock)
+	consoleLogService := NewConsoleLogService(cerberusClientMock, 30)
 	messageInRepository := NewMessageInRepository(dbConn, schemaName, 0, 0)
 	messageOutRepository := NewMessageOutRepository(dbConn, schemaName, 0, 0)
 	messageOutOrderRepository := NewMessageOutOrderRepository(dbConn, schemaName, 0)
@@ -414,7 +414,7 @@ func TestSubmitControlResultsProcessing(t *testing.T) {
 	sortingRuleService := NewSortingRuleService(analysisRepositoryMock, conditionService, sortingRuleRepository)
 
 	instrumentService := NewInstrumentService(sortingRuleService, instrumentRepository, skeletonManagerMock, NewInstrumentCache(), cerberusClientMock)
-	consoleLogService := NewConsoleLogService(cerberusClientMock)
+	consoleLogService := NewConsoleLogService(cerberusClientMock, 30)
 	messageInRepository := NewMessageInRepository(dbConn, schemaName, 0, 0)
 	messageOutRepository := NewMessageOutRepository(dbConn, schemaName, 0, 0)
 	messageOutOrderRepository := NewMessageOutOrderRepository(dbConn, schemaName, 0)
@@ -715,7 +715,7 @@ func TestSubmitAnalysisResultFieldValidations(t *testing.T) {
 	sortingRuleRepository := NewSortingRuleRepository(dbConn, schemaName)
 	sortingRuleService := NewSortingRuleService(analysisRepository, conditionService, sortingRuleRepository)
 	instrumentService := NewInstrumentService(sortingRuleService, instrumentRepository, NewSkeletonManager(ctx), NewInstrumentCache(), cerberusClientMock)
-	consoleLogService := NewConsoleLogService(cerberusClientMock)
+	consoleLogService := NewConsoleLogService(cerberusClientMock, 30)
 	messageInRepository := NewMessageInRepository(dbConn, schemaName, 0, 0)
 	messageOutRepository := NewMessageOutRepository(dbConn, schemaName, 0, 0)
 	messageOutOrderRepository := NewMessageOutOrderRepository(dbConn, schemaName, 0)
@@ -861,7 +861,7 @@ func TestSubmitControlResultsFieldValidations(t *testing.T) {
 	sortingRuleRepository := NewSortingRuleRepository(dbConn, schemaName)
 	sortingRuleService := NewSortingRuleService(analysisRepository, conditionService, sortingRuleRepository)
 	instrumentService := NewInstrumentService(sortingRuleService, instrumentRepository, NewSkeletonManager(ctx), NewInstrumentCache(), cerberusClientMock)
-	consoleLogService := NewConsoleLogService(cerberusClientMock)
+	consoleLogService := NewConsoleLogService(cerberusClientMock, 30)
 	messageInRepository := NewMessageInRepository(dbConn, schemaName, 0, 0)
 	messageOutRepository := NewMessageOutRepository(dbConn, schemaName, 0, 0)
 	messageOutOrderRepository := NewMessageOutOrderRepository(dbConn, schemaName, 0)
@@ -1097,9 +1097,7 @@ func (m *cerberusClientMock) SyncAnalysisRequests(workItemIDs []uuid.UUID, syncT
 	return nil
 }
 
-func (m *cerberusClientMock) SendConsoleLog(instrumentId uuid.UUID, logLevel LogLevel, message string, messageType string) error {
-	return nil
-}
+func (m *cerberusClientMock) SendConsoleLog(consoleLogDTOs []ConsoleLogDTO) {}
 
 func (m *cerberusClientMock) RegisterManufacturerTests(driverName string, tests []supportedManufacturerTestTO) error {
 	return nil

--- a/skeletonapi.go
+++ b/skeletonapi.go
@@ -178,7 +178,7 @@ func New(ctx context.Context, serviceName, displayName string, requestedExtraVal
 	messageOutOrderRepository := NewMessageOutOrderRepository(dbConn, dbSchema, config.MessageMaxRetries)
 	messageService := NewMessageService(deaClient, cerberusClient, messageInRepository, messageOutRepository, messageOutOrderRepository, serviceName, config.SampleSeenMessageFlushSeconds)
 
-	consoleLogService := NewConsoleLogService(cerberusClient)
+	consoleLogService := NewConsoleLogService(cerberusClient, config.ConsoleLogFlushSeconds)
 
 	longpollClient := NewLongPollClient(longPollingApiRestyClient, serviceName, config.CerberusURL, config.LongPollingAPIClientTimeoutSeconds, config.LongPollingReattemptWaitSeconds, config.LongPollingLoggingEnabled)
 


### PR DESCRIPTION
changing the console log sending to cerberus to a batched sending variant, so in case of too many errors the incoming log requests will less likely to slow down the cerberus